### PR TITLE
fix(styles): adjust root text color for dark mode visibility

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,7 +4,7 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
+  color: #213547;
   background-color: #242424;
 
   font-synthesis: none;
@@ -56,7 +56,6 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
     background-color: #ffffff;
   }
   a:hover {


### PR DESCRIPTION
Updated `:root` text color from `rgba(255, 255, 255, 0.87)` to `#213547` for better dark mode visibility